### PR TITLE
openhashtab include binary in nupkg

### DIFF
--- a/openhashtab/tools/VERIFICATION.txt
+++ b/openhashtab/tools/VERIFICATION.txt
@@ -1,0 +1,10 @@
+VERIFICATION
+Verification is intended to assist the Chocolatey moderators and community
+in verifying that this package's contents are trustworthy.
+ 
+1. Download release from 
+    32-Bit: <https://github.com/namazso/OpenHashTab/releases/download/v2.2.0/OpenHashTab_setup.exe>
+
+2. Get sha256 checksum with utility of choice
+
+3. Check that it matches checksum of included installer

--- a/openhashtab/tools/chocolateyinstall.ps1
+++ b/openhashtab/tools/chocolateyinstall.ps1
@@ -1,19 +1,15 @@
 ﻿$ErrorActionPreference = 'Stop';
-$url        = 'https://github.com/namazso/OpenHashTab/releases/download/v2.2.0/OpenHashTab_setup.exe'
-$checksum = 'ab2a232a3b2833ef92cae9053d39af90ced0ea19f653a9e09fe1389457adedee'
+$toolsDir              = Split-Path -parent $MyInvocation.MyCommand.Definition
 
 $packageArgs = @{
   packageName   = $env:ChocolateyPackageName
   fileType      = 'exe'
-  url           = $url
-
+  file          = (Get-Childitem -Path $toolsDir -Filter "*.exe").fullname
   softwareName  = 'openhashtab*'
-
-  checksum      = $checksum
-  checksumType  = 'sha256'
-
   validExitCodes= @(0, 3010, 1641)
-  silentArgs   = '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-'
+  silentArgs    = '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-'
 }
 
-Install-ChocolateyPackage @packageArgs
+Install-ChocolateyInstallPackage @packageArgs
+
+Remove-Item "$toolsDir\*.exe" -Force -EA SilentlyContinue | Out-Null

--- a/openhashtab/update.ps1
+++ b/openhashtab/update.ps1
@@ -9,16 +9,19 @@ function global:au_GetLatest {
     $url -match '/download/v([\d.]+)/OpenHashTab_setup.exe$'
     $version = $matches[1]
 	
-    return @{ Version = $version; URL = $url }
+    return @{ Version = $version; URL32 = $url }
 }
 
 function global:au_SearchReplace {
     @{
-        "tools\chocolateyInstall.ps1" = @{
-            "(^[$]url\s*=\s*)('.*')"      = "`$1'$($Latest.URL)'"
-            "(^[$]checksum\s*=\s*)('.*')" = "`$1'$($Latest.Checksum32)'"
+        ".\tools\VERIFICATION.txt" = @{
+            "(?i)(32-Bit.+)\<.*\>"     = "`${1}<$($Latest.URL32)>"
         }
     }
 }
 
-update
+function global:au_BeforeUpdate {
+  Get-RemoteFiles -Purge -NoSuffix 
+}
+
+update -ChecksumFor none


### PR DESCRIPTION
Hey @iYato 

This changes the package to include the binary in the `.nupkg` instead of downloading it at runtime. This is the recommended way to create packages, assuming that the license of the software allows redistribution and that the total size of the `.nupkg` is under 200mb. Neither of those is an issue here.
 
I also updated the AU script.

Both the AU script and the package have been tested locally by me, and are working as far as I can tell.